### PR TITLE
Make ffmpegaudio default audio engine

### DIFF
--- a/src/main/external-resources/PMS.conf
+++ b/src/main/external-resources/PMS.conf
@@ -10,7 +10,7 @@ minimized = false
 hidevideosettings = false
 usecache = false
 charsetencoding = 850
-engines = mencoder,avsmencoder,tsmuxer,mplayeraudio,ffmpegaudio,tsmuxeraudio,vlcvideo,mencoderwebvideo,mplayervideodump,mplayerwebaudio,vlcaudio,ffmpegdvrmsremux
+engines = mencoder,avsmencoder,tsmuxer,ffmpegaudio,mplayeraudio,tsmuxeraudio,vlcvideo,mencoderwebvideo,mplayervideodump,mplayerwebaudio,vlcaudio,ffmpegdvrmsremux
 autoloadsrt = true
 avisynth_convertfps = true
 avisynth_script = #AviSynth script is now fully customisable !\u0001#You must use the following variables (\"clip\" being the avisynth variable of the movie):\u0001#<movie>: insert the complete DirectShowSource instruction [ clip=DirectShowSource(movie, convertfps) ]\u0001#<sub>: insert the complete TextSub\/VobSub instruction if there's any detected srt\/sub\/idx\/ass subtitle file\u0001#<moviefilename>: variable of the movie filename, if you want to do all this by yourself\u0001#Be careful, the custom script MUST return the clip object\u0001<movie>\u0001<sub>\u0001return clip

--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -1429,7 +1429,7 @@ public class PmsConfiguration {
 	}
 
 	public List<String> getEnginesAsList(SystemUtils registry) {
-		List<String> engines = stringToList(getString(KEY_ENGINES, "mencoder,avsmencoder,tsmuxer,mplayeraudio,ffmpegaudio,tsmuxeraudio,vlcvideo,mencoderwebvideo,mplayervideodump,mplayerwebaudio,vlcaudio,ffmpegdvrmsremux,rawthumbs"));
+		List<String> engines = stringToList(getString(KEY_ENGINES, "mencoder,avsmencoder,tsmuxer,ffmpegaudio,mplayeraudio,tsmuxeraudio,vlcvideo,mencoderwebvideo,mplayervideodump,mplayerwebaudio,vlcaudio,ffmpegdvrmsremux,rawthumbs"));
 		engines = hackAvs(registry, engines);
 		return engines;
 	}


### PR DESCRIPTION
I think it make sense to make ffmpegaudio default audio engine. It is far more reliable than mplayer. 

For example cue+flac (one large file) playback is broken with mplayer, tracks play from wrong timestamp. Works fine with ffmpeg.
