### PR TITLE
Detect embedded ASS/SSA subtitles (thanks leroy!)

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -538,7 +538,9 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 						boolean hasEmbeddedSubs = false;
 						if (child.getMedia() != null) {
 							for (DLNAMediaSubtitle s : child.getMedia().getSubtitlesCodes()) {
-								hasEmbeddedSubs |= s.getSubType().equals("Embedded");
+								// Check for embedded subtitles. Embedded ASS/SSA subs must be checked explicitly for the ASS/SSA Sub-type
+								String subtype = s.getSubType();
+								hasEmbeddedSubs |= (subtype.equals("Embedded") || (subtype.equals("ASS/SSA") && s.getFile() == null));
 							}
 						}
 


### PR DESCRIPTION
Embedded ASS/SSA subtitles were being ignored during the check for embedded subtitles. As a result, under certain circumstances videos with ASS/SSA subtitles would forego transcoding. See [this](http://www.ps3mediaserver.org/forum/viewtopic.php?f=11&t=13242&start=10#p64392) post.

It turns out that embedded ASS/SSA subtitles are not given the "embedded" type like other embedded subtitles. They are explicitly checked for and now detect properly for both the embedded and external case.
