### PR TITLE
PS3 with fw 4.0 supports MPEG4 ASP with Qpel

### DIFF
--- a/src/main/external-resources/renderers/PS3.conf
+++ b/src/main/external-resources/renderers/PS3.conf
@@ -420,7 +420,7 @@ AutoExifRotate = true
 Supported = f:mpegps|mpegts    v:mpeg1|mpeg2|mp4|h264    a:ac3|lpcm|aac|mpa        m:video/mpeg
 # No H264 for AVI files, plus specific mediainfo attributes, for better auto
 # detection (qpel and gmc are not supported here)
-Supported = f:avi|divx    v:mp4|divx|mjpeg        a:mp3|lpcm|mpa|ac3        m:video/x-divx        qpel:no        gmc:0
+Supported = f:avi|divx    v:mp4|divx|mjpeg        a:mp3|lpcm|mpa|ac3        m:video/x-divx        gmc:0
 Supported = f:mp4    v:mp4|h264        a:ac3|aac        m:video/mp4
 # WMV files are supported, but not with 5.1 audio: (hence the n:2)
 Supported = f:wmv    v:wmv|vc1        a:wma        n:2        m:video/x-ms-wmv


### PR DESCRIPTION
PS3 now has native support for avi files with Qpel. GMC is still unsupported though.

I uploaded DivvTest files here: [video-compatibility-tests](http://www.mediafire.com/?fo4b48iiwr3b2). Greate help for troubleshooting.
