### PR TITLE
Display duration as hour:second:minute instead of number

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -1218,7 +1218,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 					if (getMedia() != null && getMedia().isMediaparsed()) {
 						addAttribute(sb, "bitrate", getMedia().getBitrate());
 						if (getMedia().getDuration() != null) {
-							addAttribute(sb, "duration", getMedia().getDuration());
+							addAttribute(sb, "duration", DLNAMediaInfo.getDurationString(getMedia().getDuration()));
 						}
 						if (firstAudioTrack != null && firstAudioTrack.getSampleFrequency() != null) {
 							addAttribute(sb, "sampleFrequency", firstAudioTrack.getSampleFrequency());


### PR DESCRIPTION
Trying to fix this issue :
https://github.com/ps3mediaserver/ps3mediaserver/commit/da361e91c9a9f6919f5f92db0428b8c1bcdd3ddb#commitcomment-920382
