### PR TITLE
Fix project.binaries.dir typo

### DIFF
--- a/src/main/java/net/pms/configuration/LinuxDefaultPaths.java
+++ b/src/main/java/net/pms/configuration/LinuxDefaultPaths.java
@@ -56,7 +56,7 @@ class LinuxDefaultPaths implements ProgramPaths {
 	 * @return The path for binaries.
 	 */
 	private String getBinariesPath() {
-		String path = PropertiesUtil.getProjectProperties().get("project.binaries");
+		String path = PropertiesUtil.getProjectProperties().get("project.binaries.dir");
 
 		if (path != null && !"".equals(path)) {
 			if (path.endsWith("/")) {

--- a/src/main/java/net/pms/configuration/MacDefaultPaths.java
+++ b/src/main/java/net/pms/configuration/MacDefaultPaths.java
@@ -56,7 +56,7 @@ class MacDefaultPaths implements ProgramPaths {
 	 * @return The path for binaries.
 	 */
 	private String getBinariesPath() {
-		String path = PropertiesUtil.getProjectProperties().get("project.binaries");
+		String path = PropertiesUtil.getProjectProperties().get("project.binaries.dir");
 
 		if (path != null && !"".equals(path)) {
 			if (path.endsWith("/")) {

--- a/src/main/java/net/pms/configuration/WindowsDefaultPaths.java
+++ b/src/main/java/net/pms/configuration/WindowsDefaultPaths.java
@@ -56,7 +56,7 @@ class WindowsDefaultPaths implements ProgramPaths {
 	 * @return The path for binaries.
 	 */
 	private String getBinariesPath() {
-		String path = PropertiesUtil.getProjectProperties().get("project.binaries");
+		String path = PropertiesUtil.getProjectProperties().get("project.binaries.dir");
 
 		if (path != null && !"".equals(path)) {
 			if (path.endsWith("/")) {


### PR DESCRIPTION
Fix project.binaries.dir typo. Critical bug leading to binary tools not found.
