### PR TITLE
Fix download pms binaries source

### DIFF
--- a/contrib/download-pms-binaries-source.sh
+++ b/contrib/download-pms-binaries-source.sh
@@ -280,6 +280,7 @@ download_ffmpeg() {
         $GIT checkout ${VERSION_FFMPEG}
         exit_on_error
     fi
+    rm -rf ./.git
 }
 
 


### PR DESCRIPTION
- Fix download_tsmuxer duplication for OSX (_download_tsMuxeR()_ and _download_tsmuxer()_)
- Clean ffmpeg source
