### PR TITLE
Updated jna to 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,7 @@
 		<dependency>
 			<groupId>net.java.dev.jna</groupId>
 			<artifactId>jna</artifactId>
-			<version>3.2.5</version>
+			<version>3.4.0</version>
 		</dependency>
 
 		<!-- XXX: not Mavenized: http://www.jgoodies.com/downloads/libraries.html -->


### PR DESCRIPTION
Updated jna to solve the problem that native libraries can not be found if using linux with multiarch. See also: https://code.google.com/p/ps3mediaserver/issues/detail?id=1152#c3
