### PR TITLE
Force language because JUnit tests depend on english language strings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -433,6 +433,10 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
+					<configuration>
+						<!-- Force language because JUnit tests depend on english language strings -->
+						<argLine>-Duser.language=en</argLine>
+					</configuration>
 					<version>2.11</version>
 				</plugin>
 				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->

--- a/src/test/java/net/pms/test/RendererConfigurationTest.java
+++ b/src/test/java/net/pms/test/RendererConfigurationTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertNotNull;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -48,9 +49,12 @@ public class RendererConfigurationTest {
 
 	@Before
 	public void setUp() {
-        // Silence all log messages from the PMS code that is being tested
-        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
-        context.reset(); 
+		// Silence all log messages from the PMS code that is being tested
+		LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+		context.reset(); 
+		
+		// Set locale to EN to ignore translations for renderers
+		Locale.setDefault(Locale.ENGLISH);
 
 		// Cases that are too generic should not match anything
 		testCases.put("User-Agent: UPnP/1.0 DLNADOC/1.50", null);


### PR DESCRIPTION
- Fix in pom.xml to fix build for non-english environments (e.g. german)
- Fix in RendererConfigurationTest.java for running JUnit tests in eclipse

Error message from failed maven build:

[...]
Running net.pms.test.RendererConfigurationTest
Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.068 sec <<< FAILURE!

Results :

Failed tests:   testBogusDefault(net.pms.test.RendererConfigurationTest): Expected renderer "Unknown renderer", instead renderer "Unbekannter DLNA Client" was returned for header "User-Agent: AirPlayer/1.0.09 CFNetwork/485.13.9 Darwin/11.0.0" expected:<Un[known renderer]> but was:<Un[bekannter DLNA Client]>
[...]
