### PR TITLE
Load system-wide defaults from /etc/skel if user's profile not found

### DIFF
--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import net.pms.io.SystemUtils;
 import net.pms.Messages;
 
+import net.pms.util.PropertiesUtil;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.ConversionException;
@@ -273,10 +274,12 @@ public class PmsConfiguration {
 	private static final String ENV_PROFILE_PATH = "PMS_PROFILE";
 	private static final String PROFILE_DIRECTORY; // path to directory containing PMS config files
 	private static final String PROFILE_PATH; // abs path to profile file e.g. /path/to/PMS.conf
+    private static final String SKEL_PROFILE_PATH ; // abs path to skel (default) profile file e.g. /etc/skel/.config/ps3mediaserver/PMS.conf
+                                                    // "project.skelprofile.dir" project property
 	private static final String PROPERTY_PROFILE_PATH = "pms.profile.path";
 
 	static {
-		// first try the system property, typically set via the profile chooser
+        // first try the system property, typically set via the profile chooser
 		String profile = System.getProperty(PROPERTY_PROFILE_PATH);
 
 		// failing that, try the environment variable
@@ -334,6 +337,13 @@ public class PmsConfiguration {
 
 			PROFILE_PATH = FilenameUtils.normalize(new File(PROFILE_DIRECTORY, DEFAULT_PROFILE_FILENAME).getAbsolutePath());
 		}
+        // set SKEL_PROFILE_PATH for Linux systems
+        String skelDir = PropertiesUtil.getProjectProperties().get("project.skelprofile.dir");
+        if (Platform.isLinux() && StringUtils.isNotBlank(skelDir)) {
+            SKEL_PROFILE_PATH = FilenameUtils.normalize(new File(new File(skelDir, PROFILE_DIRECTORY_NAME).getAbsolutePath(), DEFAULT_PROFILE_FILENAME).getAbsolutePath());
+        } else {
+            SKEL_PROFILE_PATH = null;
+        }
 	}
 
 	/**
@@ -359,17 +369,25 @@ public class PmsConfiguration {
 	public PmsConfiguration(boolean loadFile) throws ConfigurationException, IOException {
 		configuration = new PropertiesConfiguration();
 		configuration.setListDelimiter((char) 0);
-		configuration.setFileName(PROFILE_PATH);
 
 		if (loadFile) {
 			File pmsConfFile = new File(PROFILE_PATH);
 	
-			if (pmsConfFile.exists() && pmsConfFile.isFile()) {
+			if (pmsConfFile.isFile() && pmsConfFile.canRead()) {
 				configuration.load(PROFILE_PATH);
-			}
+			} else if (SKEL_PROFILE_PATH != null) {
+                File pmsSkelConfFile = new File(SKEL_PROFILE_PATH);
+                if (pmsSkelConfFile.isFile() && pmsSkelConfFile.canRead()) {
+                    // load defaults from skel file, save them later to PROFILE_PATH
+                    configuration.load(pmsSkelConfFile);
+                    logger.info("Default configuration loaded from " + SKEL_PROFILE_PATH);
+                }
+            }
 		}
 
-		tempFolder = new TempFolder(getString(KEY_TEMP_FOLDER_PATH, null));
+        configuration.setPath(PROFILE_PATH);
+
+        tempFolder = new TempFolder(getString(KEY_TEMP_FOLDER_PATH, null));
 		programPaths = createProgramPathsChain(configuration);
 		Locale.setDefault(new Locale(getLanguage()));
 		// set DEFAULT_AVI_SYNTH_SCRIPT properly according to language

--- a/src/main/resources/project.properties
+++ b/src/main/resources/project.properties
@@ -6,6 +6,7 @@ project.binaries.dir=
 project.documentation.dir=documentation
 project.logback=logback.xml
 project.logback.headless=logback.headless.xml
+project.skelprofile.dir=/etc/skel/.config
 
 # Git commit information from the git-commit-id-plugin
 git.commit.id=${git.commit.id}

--- a/src/test/resources/project.properties
+++ b/src/test/resources/project.properties
@@ -6,6 +6,7 @@ project.binaries.dir=${project.binaries}
 project.documentation.dir=src/main/external-resources/documentation
 project.logback=src/main/external-resources/logback.xml
 project.logback.headless=src/main/external-resources/logback.headless.xml
+project.skelprofile.dir=/etc/skel/.config
 
 # Git commit information from the git-commit-id-plugin
 git.commit.id=${git.commit.id}


### PR DESCRIPTION
Better configs management for Linux systems. 
If user's `PMS.conf` not found load defaults from `/etc/skel/.config/PMS/PMS.conf` and save them to home `.config` directory.
