### PR TITLE
javadoc and source plugins added to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -874,7 +874,17 @@
 
 					</reportPlugins>
 				</configuration>
-			</plugin> 
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>2.1.2</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.8.1</version>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
In order to ease plugin development, added maven plugins to generate javadoc and source jars of PMS to pom.xml. This change does no interfere normal building, unless parameters "javadoc:jar source:jar" are passed to mvn.
