### PR TITLE
#--TRANSCODE--# folder renaming

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -66,7 +66,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 	private static final Logger LOGGER = LoggerFactory.getLogger(DLNAResource.class);
 	protected static final int MAX_ARCHIVE_ENTRY_SIZE = 10000000;
 	protected static final int MAX_ARCHIVE_SIZE_SEEK = 800000000;
-	protected static final String TRANSCODE_FOLDER = "#--TRANSCODE--#";
+	protected static final String TRANSCODE_FOLDER = "#- Language and player selection -#";
 	private final Map<String, Integer> requestIdToRefcount = new HashMap<String, Integer>();
 	private static final int STOP_PLAYING_DELAY = 4000;
 	private static final SimpleDateFormat SDF_DATE = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US);


### PR DESCRIPTION
Reasons for **#--TRANSCODE--#** folder renaming:
~pedantic mode on~
1. Confusing title. Users do not know what _Transcoding_ means.
2. Misleading title. Main use case for this folder is audio/subs selection. 
3. Incorrect title. At least two engines in _Transcode_ folder (tsmuxer and native) do not actually perform transcoding. Neither there are any guaranties that entities outside _Transcode_ folder are not transcoded.

I think any of this reasons alone is enough to do renaming.
Random thoughts about what can be done better:
- localization
- ? config / gui option to set up any title
