### PR TITLE
Rename RendererUniqueId -> RendererId

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,7 +12,7 @@ Changelog:
     Fixed DV videos detection
     Added support for WebM YouTube videos (with ffmpeg player)
     Optimized CBRVideoBitrate value for Panasonic TVs (thanks, ExSport!)
-    Added RendererUniqueID to renderers' configs
+    Added RendererID to renderers' configs
     Added new renderer: Sony SMP-N100 (thanks, mrw1986 and guillepalao!)
     Language updates:
         - Catalan translation update (thanks, aseques!)

--- a/src/main/external-resources/renderers/PS3.conf
+++ b/src/main/external-resources/renderers/PS3.conf
@@ -16,11 +16,11 @@
 # interface when this renderer connects.
 RendererName = Playstation 3
 
-# RendererUniqueID: Determines renderer's unique ID. PS3 Media Server may apply
-# workarounds specific to this client type based on RendererUniqueID.
+# RendererID: Declares an identifier for this renderer. PS3 Media Server may apply
+# workarounds specific to this client type based on this ID.
 # Defaults to RendererName if not set.
-# !DO NOT CHANGE!
-RendererUniqueID = ps3
+# XXX DO NOT CHANGE
+RendererID = ps3
 
 # RendererIcon: Determines the icon that is displayed in the PMS user
 # interface when this renderer connects. By default, these icons are

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -249,7 +249,7 @@ public class RendererConfiguration {
 		return rank;
 	}
 
-	// Those 'is' methods should disappear. Use getRendererUniqueID() instead.
+	// These 'is' methods should disappear. Use getRendererID() instead.
 	@Deprecated
 	public boolean isXBOX() {
 		return getRendererName().toUpperCase().contains("XBOX");
@@ -266,7 +266,7 @@ public class RendererConfiguration {
 	}
 
 	private static final String RENDERER_NAME = "RendererName";
-	private static final String RENDERER_UNIQUE_ID = "RendererUniqueID";
+	private static final String RENDERER_ID = "RendererID";
 	private static final String RENDERER_ICON = "RendererIcon";
 	private static final String USER_AGENT = "UserAgentSearch";
 	private static final String USER_AGENT_ADDITIONAL_HEADER = "UserAgentAdditionalHeader";
@@ -602,14 +602,14 @@ public class RendererConfiguration {
 	}
 
 	/**
-	 * RendererUniqueID: Determines renderer's unique ID. PS3 Media Server may apply
-	 * workarounds specific to this client type based on RendererUniqueID. Defaults
+	 * RendererID: Returns the renderer's ID. PS3 Media Server may apply
+	 * workarounds specific to this client type based on this ID. Defaults
 	 * to RendererName if not set.
 	 *
-	 * @return The renderer unique ID.
+	 * @return The renderer ID.
 	 */
-	public String getRendererUniqueID() {
-		return getString(RENDERER_UNIQUE_ID, getRendererName());
+	public String getRendererID() {
+		return getString(RENDERER_ID, getRendererName());
 	}
 
 	/**
@@ -699,7 +699,7 @@ public class RendererConfiguration {
 		if (isMediaParserV2()) {
 			return getFormatConfiguration().isMpeg2Supported();
 		}
-		return getRendererUniqueID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3);
+		return getRendererID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3);
 	}
 
 	/**

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -1082,15 +1082,14 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 				flags = "DLNA.ORG_OP=01";
 				if (getPlayer() != null) {
 					if (getPlayer().isTimeSeekable() && mediaRenderer.isSeekByTime()) {
-						if (mediaRenderer.getRendererUniqueID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3)) // ps3 doesn't like OP=11
-						{
+						if (mediaRenderer.getRendererID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3)) { // PS3 doesn't like OP=11
 							flags = "DLNA.ORG_OP=10";
 						} else {
 							flags = "DLNA.ORG_OP=11";
 						}
 					}
 				} else {
-					if (mediaRenderer.isSeekByTime() && !mediaRenderer.getRendererUniqueID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3)) {
+					if (mediaRenderer.isSeekByTime() && !mediaRenderer.getRendererID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3)) {
 						flags = "DLNA.ORG_OP=11";
 					}
 				}
@@ -1100,7 +1099,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 				if (mime == null) {
 					mime = "video/mpeg";
 				}
-				if (mediaRenderer.getRendererUniqueID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3)) { // XXX TO REMOVE, OR AT LEAST MAKE THIS GENERIC // whole extensions/mime-types mess to rethink anyway
+				if (mediaRenderer.getRendererID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3)) { // XXX TO REMOVE, OR AT LEAST MAKE THIS GENERIC // whole extensions/mime-types mess to rethink anyway
 					if (mime.equals("video/x-divx")) {
 						dlnaspec = "DLNA.ORG_PN=AVI";
 					} else if (mime.equals("video/x-ms-wmv") && getMedia() != null && getMedia().getHeight() > 700) {

--- a/src/main/java/net/pms/encoders/MEncoderVideo.java
+++ b/src/main/java/net/pms/encoders/MEncoderVideo.java
@@ -1326,7 +1326,10 @@ public class MEncoderVideo extends Player {
 		mpegts = params.mediaRenderer.isTranscodeToMPEGTSAC3();
 
         // disable AC3 remux for stereo tracks with 384 kbits bitrate and PS3 renderer (PS3 FW bug?)
-        boolean ps3_and_stereo_and_384_kbits = params.aid != null && (params.mediaRenderer.getRendererUniqueID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3) && params.aid.getAudioProperties().getNumberOfChannels() == 2) && (params.aid.getBitRate() > 370000 && params.aid.getBitRate() < 400000);
+        boolean ps3_and_stereo_and_384_kbits = params.aid != null
+			&& (params.mediaRenderer.getRendererID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3) && params.aid.getAudioProperties().getNumberOfChannels() == 2)
+			&& (params.aid.getBitRate() > 370000 && params.aid.getBitRate() < 400000);
+
         if (configuration.isRemuxAC3() && params.aid != null && params.aid.isAC3() && !ps3_and_stereo_and_384_kbits && !avisynth() && params.mediaRenderer.isTranscodeToAC3()) {
 			// AC3 remux takes priority
 			ac3Remux = true;

--- a/src/main/java/net/pms/encoders/TSMuxerVideo.java
+++ b/src/main/java/net/pms/encoders/TSMuxerVideo.java
@@ -191,7 +191,7 @@ public class TSMuxerVideo extends Player {
 
 			if (media != null) {
 				boolean compat = (media.isVideoPS3Compatible(newInput) || !params.mediaRenderer.isH264Level41Limited());
-				if (!compat && params.mediaRenderer.getRendererUniqueID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3)) {
+				if (!compat && params.mediaRenderer.getRendererID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3)) {
 					logger.info("The video will not play or show a black screen on the ps3...");
 				}
 				if (media.getH264AnnexB() != null && media.getH264AnnexB().length > 0) {
@@ -229,7 +229,7 @@ public class TSMuxerVideo extends Player {
 					ffAudioPipe = new PipeIPCProcess[numAudioTracks];
 					ffAudioPipe[0] = new PipeIPCProcess(System.currentTimeMillis() + "ffmpegaudio01", System.currentTimeMillis() + "audioout", false, true);
                     // disable AC3 remux for stereo tracks with 384 kbits bitrate and PS3 renderer (PS3 FW bug?)
-                    boolean ps3_and_stereo_and_384_kbits = (params.mediaRenderer.getRendererUniqueID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3) && params.aid.getAudioProperties().getNumberOfChannels() == 2) && (params.aid.getBitRate() > 370000 && params.aid.getBitRate() < 400000);
+                    boolean ps3_and_stereo_and_384_kbits = (params.mediaRenderer.getRendererID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3) && params.aid.getAudioProperties().getNumberOfChannels() == 2) && (params.aid.getBitRate() > 370000 && params.aid.getBitRate() < 400000);
 					ac3Remux = (params.aid.isAC3() && !ps3_and_stereo_and_384_kbits && configuration.isRemuxAC3());
                     dtsRemux = configuration.isDTSEmbedInPCM() && params.aid.isDTS() && params.mediaRenderer.isDTSPlayable();
 					pcm = configuration.isMencoderUsePcm() &&
@@ -347,7 +347,7 @@ public class TSMuxerVideo extends Player {
 						DLNAMediaAudio audio = media.getAudioTracksList().get(i);
 						ffAudioPipe[i] = new PipeIPCProcess(System.currentTimeMillis() + "ffmpeg" + i, System.currentTimeMillis() + "audioout" + i, false, true);
                         // disable AC3 remux for stereo tracks with 384 kbits bitrate and PS3 renderer (PS3 FW bug?)
-                        boolean ps3_and_stereo_and_384_kbits = (params.mediaRenderer.getRendererUniqueID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3) && audio.getAudioProperties().getNumberOfChannels() == 2) && (audio.getBitRate() > 370000 && audio.getBitRate() < 400000);
+                        boolean ps3_and_stereo_and_384_kbits = (params.mediaRenderer.getRendererID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3) && audio.getAudioProperties().getNumberOfChannels() == 2) && (audio.getBitRate() > 370000 && audio.getBitRate() < 400000);
                         ac3Remux = audio.isAC3() && !ps3_and_stereo_and_384_kbits && configuration.isRemuxAC3();
 						dtsRemux = configuration.isDTSEmbedInPCM() && audio.isDTS() && params.mediaRenderer.isDTSPlayable();
 						pcm = configuration.isMencoderUsePcm() &&
@@ -487,7 +487,7 @@ public class TSMuxerVideo extends Player {
 			boolean ac3Remux = false;
 			boolean dtsRemux = false;
 			boolean pcm = false;
-            boolean ps3_and_stereo_and_384_kbits = (params.mediaRenderer.getRendererUniqueID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3) && params.aid.getAudioProperties().getNumberOfChannels() == 2) && (params.aid.getBitRate() > 370000 && params.aid.getBitRate() < 400000);
+            boolean ps3_and_stereo_and_384_kbits = (params.mediaRenderer.getRendererID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3) && params.aid.getAudioProperties().getNumberOfChannels() == 2) && (params.aid.getBitRate() > 370000 && params.aid.getBitRate() < 400000);
             ac3Remux = params.aid.isAC3() && !ps3_and_stereo_and_384_kbits && configuration.isRemuxAC3();
 			dtsRemux = configuration.isDTSEmbedInPCM() && params.aid.isDTS() && params.mediaRenderer.isDTSPlayable();
 			pcm = configuration.isMencoderUsePcm() &&
@@ -536,7 +536,8 @@ public class TSMuxerVideo extends Player {
 				boolean ac3Remux = false;
 				boolean dtsRemux = false;
 				boolean pcm = false;
-                boolean ps3_and_stereo_and_384_kbits = (params.mediaRenderer.getRendererUniqueID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3) && lang.getAudioProperties().getNumberOfChannels() == 2) && (lang.getBitRate() > 370000 && lang.getBitRate() < 400000);
+                boolean ps3_and_stereo_and_384_kbits = (params.mediaRenderer.getRendererID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3) && lang.getAudioProperties().getNumberOfChannels() == 2)
+					&& (lang.getBitRate() > 370000 && lang.getBitRate() < 400000);
                 ac3Remux = lang.isAC3() && !ps3_and_stereo_and_384_kbits && configuration.isRemuxAC3();
 				dtsRemux = configuration.isDTSEmbedInPCM() && lang.isDTS() && params.mediaRenderer.isDTSPlayable();
 				pcm = configuration.isMencoderUsePcm() &&

--- a/src/main/java/net/pms/network/RequestV2.java
+++ b/src/main/java/net/pms/network/RequestV2.java
@@ -477,7 +477,7 @@ public class RequestV2 extends HTTPResource {
 					s = s.replace("PS3 Media Server", "PS3 Media Server [" + profileName + "]");
 				}
 
-				if (!mediaRenderer.getRendererUniqueID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3)) {
+				if (!mediaRenderer.getRendererID().equalsIgnoreCase(RENDERER_ID_PLAYSTATION3)) {
 					// hacky stuff. replace the png icon by a jpeg one. Like mpeg2 remux,
 					// really need a proper format compatibility list by renderer
 					s = s.replace("<mimetype>image/png</mimetype>", "<mimetype>image/jpeg</mimetype>");

--- a/src/test/java/net/pms/test/RendererConfigurationTest.java
+++ b/src/test/java/net/pms/test/RendererConfigurationTest.java
@@ -191,7 +191,7 @@ public class RendererConfigurationTest {
 	}
 
 	@Test
-	public void testRendererUniqueID() {
+	public void testRendererID() {
 		PmsConfiguration pmsConf = null;
 
 		try {
@@ -208,9 +208,9 @@ public class RendererConfigurationTest {
 		loadRendererConfigurations(pmsConf);
 
 		RendererConfiguration rc = getRendererConfigurationByUA("\"User-Agent: PLAYSTATION 3\", \"Playstation 3\"");
-		assertEquals("RendererUniqueID for PlayStation 3", RENDERER_ID_PLAYSTATION3, rc.getRendererUniqueID());
+		assertEquals("RendererID for PlayStation 3", RENDERER_ID_PLAYSTATION3, rc.getRendererID());
 		rc = getRendererConfigurationByUA("User-Agent: Windows2000/0.0 UPnP/1.0 PhilipsIntelSDK/1.4 DLNADOC/1.50");
-		assertEquals("RendererUniqueID for PhilipsPFL is not set and defaults to RendererName", "Philips TV", rc.getRendererUniqueID());
+		assertEquals("RendererID for Philips PFL is not set and defaults to RendererName", "Philips TV", rc.getRendererID());
 	}
 
 	/**


### PR DESCRIPTION
The identifiers aren't unique i.e. they may be shared by multiple renderers (e.g. [Sony Bravia confs](https://github.com/valib/ps3mediaserver/commit/697fbb0d08494db049e6831b41b8758b19665f4e)) rather than being unique to each file.
