### PR TITLE
Don't use disabled engines

### DIFF
--- a/src/main/java/net/pms/dlna/FileTranscodeVirtualFolder.java
+++ b/src/main/java/net/pms/dlna/FileTranscodeVirtualFolder.java
@@ -21,17 +21,11 @@ package net.pms.dlna;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.List;
-
 import net.pms.PMS;
-import net.pms.configuration.PmsConfiguration;
 import net.pms.configuration.RendererConfiguration;
 import net.pms.dlna.virtual.VirtualFolder;
-import net.pms.encoders.MEncoderVideo;
 import net.pms.encoders.Player;
 import net.pms.encoders.PlayerFactory;
-import net.pms.encoders.TSMuxerVideo;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -149,7 +143,7 @@ public class FileTranscodeVirtualFolder extends VirtualFolder {
 					DLNAResource tempModifiedCopy = createModifiedResource(child, audio, subtitle);
 			
 					// Determine which players match this audio track and subtitle
-					ArrayList<Player> players = PlayerFactory.getPlayers(tempModifiedCopy);
+					ArrayList<Player> players = PlayerFactory.getEnabledPlayers(tempModifiedCopy);
 
 					for (Player player : players) {
 						// Create a copy based on this combination

--- a/src/main/java/net/pms/encoders/PlayerFactory.java
+++ b/src/main/java/net/pms/encoders/PlayerFactory.java
@@ -27,7 +27,6 @@ import java.util.Comparator;
 
 import net.pms.PMS;
 import net.pms.configuration.PmsConfiguration;
-import net.pms.dlna.DLNAMediaInfo;
 import net.pms.dlna.DLNAResource;
 import net.pms.formats.Format;
 import net.pms.formats.FormatFactory;
@@ -332,5 +331,33 @@ public final class PlayerFactory {
 		}
 
 		return compatiblePlayers;
+	}
+
+	/**
+	 * Returns all {@link Player}s that match the given resource and are enabled. Each of the
+	 * available players is passed the provided information and each player that
+	 * reports it is compatible will be returned.
+	 * 
+	 * @param resource
+	 *            The {@link DLNAResource} to match
+	 * @return The player if a match could be found, <code>null</code>
+	 *         otherwise.
+	 * @since 1.70.0
+	 */
+	public static ArrayList<Player> getEnabledPlayers(final DLNAResource resource) {
+		if (resource == null) {
+			return null;
+		}
+
+		List<String> enabledEngines = PMS.getConfiguration().getEnginesAsList(PMS.get().getRegistry());
+		ArrayList<Player> enabledPlayers = new ArrayList<Player>();
+		
+		for (Player player : getPlayers(resource)) {
+			if (enabledEngines.contains(player.id())) {
+				enabledPlayers.add(player);
+			}
+		}
+
+		return enabledPlayers;
 	}
 }


### PR DESCRIPTION
Entries for players having been disabled in the transcode settings still show up in the transcode folder. They shouldn't, right?
