### PR TITLE
Use generic List instead of ArrayList as type

### DIFF
--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -48,6 +48,8 @@ import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.util.*;
+import java.util.List;
+
 
 /**
  * This class keeps track of scanned MediaInfo library information.
@@ -128,8 +130,8 @@ public class DLNAMediaInfo implements Cloneable {
 	@Deprecated
 	public int bitsPerPixel;
 
-	private ArrayList<DLNAMediaAudio> audioTracks = new ArrayList<DLNAMediaAudio>();
-	private ArrayList<DLNAMediaSubtitle> subtitleTracks = new ArrayList<DLNAMediaSubtitle>();
+	private List<DLNAMediaAudio> audioTracks = new ArrayList<DLNAMediaAudio>();
+	private List<DLNAMediaSubtitle> subtitleTracks = new ArrayList<DLNAMediaSubtitle>();
 
 	/**
 	 * @deprecated Use standard getter and setter to access this variable.
@@ -1455,7 +1457,7 @@ public class DLNAMediaInfo implements Cloneable {
 	 * @return the audioTracks
 	 * @since 1.60
 	 */
-	public ArrayList<DLNAMediaAudio> getAudioTracksList() {
+	public List<DLNAMediaAudio> getAudioTracksList() {
 		return audioTracks;
 	}
 
@@ -1465,14 +1467,18 @@ public class DLNAMediaInfo implements Cloneable {
 	 */
 	@Deprecated
 	public ArrayList<DLNAMediaAudio> getAudioCodes() {
-		return getAudioTracksList();
+		if(audioTracks instanceof ArrayList) {
+			return (ArrayList<DLNAMediaAudio>) audioTracks;
+		} else {
+			return new ArrayList<DLNAMediaAudio>();
+		}
 	}
 
 	/**
 	 * @param audioTracks the audioTracks to set
 	 * @since 1.60
 	 */
-	public void setAudioTracksList(ArrayList<DLNAMediaAudio> audioTracks) {
+	public void setAudioTracksList(List<DLNAMediaAudio> audioTracks) {
 		this.audioTracks = audioTracks;
 	}
 
@@ -1481,7 +1487,7 @@ public class DLNAMediaInfo implements Cloneable {
 	 * @deprecated use setAudioTracksList(ArrayList<DLNAMediaAudio> audioTracks) instead
 	 */
 	@Deprecated
-	public void setAudioCodes(ArrayList<DLNAMediaAudio> audioTracks) {
+	public void setAudioCodes(List<DLNAMediaAudio> audioTracks) {
 		setAudioTracksList(audioTracks);
 	}
 
@@ -1489,7 +1495,7 @@ public class DLNAMediaInfo implements Cloneable {
 	 * @return the subtitleTracks
 	 * @since 1.60
 	 */
-	public ArrayList<DLNAMediaSubtitle> getSubtitleTracksList() {
+	public List<DLNAMediaSubtitle> getSubtitleTracksList() {
 		return subtitleTracks;
 	}
 
@@ -1499,14 +1505,18 @@ public class DLNAMediaInfo implements Cloneable {
 	 */
 	@Deprecated
 	public ArrayList<DLNAMediaSubtitle> getSubtitlesCodes() {
-		return getSubtitleTracksList();
+		if(subtitleTracks instanceof ArrayList) {
+			return (ArrayList<DLNAMediaSubtitle>) subtitleTracks;
+		} else {
+			return new ArrayList<DLNAMediaSubtitle>();
+		}
 	}
 
 	/**
 	 * @param subtitleTracks the subtitleTracks to set
 	 * @since 1.60
 	 */
-	public void setSubtitleTracksList(ArrayList<DLNAMediaSubtitle> subtitleTracks) {
+	public void setSubtitleTracksList(List<DLNAMediaSubtitle> subtitleTracks) {
 		this.subtitleTracks = subtitleTracks;
 	}
 
@@ -1515,7 +1525,7 @@ public class DLNAMediaInfo implements Cloneable {
 	 * @deprecated use setSubtitleTracksList(ArrayList<DLNAMediaSubtitle> subtitleTracks) instead
 	 */
 	@Deprecated
-	public void setSubtitlesCodes(ArrayList<DLNAMediaSubtitle> subtitleTracks) {
+	public void setSubtitlesCodes(List<DLNAMediaSubtitle> subtitleTracks) {
 		setSubtitleTracksList(subtitleTracks);
 	}
 

--- a/src/main/java/net/pms/dlna/FileTranscodeVirtualFolder.java
+++ b/src/main/java/net/pms/dlna/FileTranscodeVirtualFolder.java
@@ -133,8 +133,8 @@ public class FileTranscodeVirtualFolder extends VirtualFolder {
 			// List holding all combinations
 			ArrayList<DLNAResource> combos = new ArrayList<DLNAResource>();
 
-			ArrayList<DLNAMediaAudio> audioTracks = child.getMedia().getAudioTracksList();
-			ArrayList<DLNAMediaSubtitle> subtitles = child.getMedia().getSubtitleTracksList();
+			List<DLNAMediaAudio> audioTracks = child.getMedia().getAudioTracksList();
+			List<DLNAMediaSubtitle> subtitles = child.getMedia().getSubtitleTracksList();
 
 			// Make sure a combo with no subtitles will be added
 			DLNAMediaSubtitle noSubtitle = new DLNAMediaSubtitle();


### PR DESCRIPTION
No need to force using an typed list. This could also be applied to [PlayerFactory](https://github.com/ps3mediaserver/ps3mediaserver/blob/master/src/main/java/net/pms/encoders/PlayerFactory.java#L321)
This is a breaking change.
