### PR TITLE
OutputParams PATH fix

### DIFF
--- a/src/main/java/net/pms/io/ProcessWrapperImpl.java
+++ b/src/main/java/net/pms/io/ProcessWrapperImpl.java
@@ -132,8 +132,9 @@ public class ProcessWrapperImpl extends Thread implements ProcessWrapper {
 			}
 			if (params.env != null && !params.env.isEmpty()) {
 				Map<String,String> environment = pb.environment();
-				params.env.put("PATH", params.env.get("PATH") + File.pathSeparator + environment.get("PATH"));
+				String PATH = params.env.get("PATH") + File.pathSeparator + environment.get("PATH");
 				environment.putAll(params.env);
+				environment.put("PATH", PATH);
 			}
 			process = pb.start();
 			PMS.get().currentProcesses.add(process);


### PR DESCRIPTION
This fixes handling of PATH in ProcessWrapperImpl.java in https://github.com/ps3mediaserver/ps3mediaserver/pull/75 . As originally written prepended PATH would be duplicated if the OutputParams object is re-used.
