### PR TITLE
OutputParams PATH fix contd

### DIFF
--- a/src/main/java/net/pms/io/ProcessWrapperImpl.java
+++ b/src/main/java/net/pms/io/ProcessWrapperImpl.java
@@ -132,9 +132,19 @@ public class ProcessWrapperImpl extends Thread implements ProcessWrapper {
 			}
 			if (params.env != null && !params.env.isEmpty()) {
 				Map<String,String> environment = pb.environment();
-				String PATH = params.env.get("PATH") + File.pathSeparator + environment.get("PATH");
+				// actual name of system path var is case-sensitive
+				String sysPathKey = PMS.get().isWindows() ? "Path" : "PATH";
+				// as is Map
+				String PATH = params.env.containsKey("PATH") ? params.env.get("PATH") :
+					params.env.containsKey("path") ? params.env.get("path") :
+					params.env.containsKey("Path") ? params.env.get("Path") : null;
+				if (PATH != null) {
+					PATH += (File.pathSeparator + environment.get(sysPathKey));
+				}
 				environment.putAll(params.env);
-				environment.put("PATH", PATH);
+				if (PATH != null) {
+					environment.put(sysPathKey, PATH);
+				}
 			}
 			process = pb.start();
 			PMS.get().currentProcesses.add(process);


### PR DESCRIPTION
Previous version failed in Windows because "PATH" was being set instead of "Path".
