### PR TITLE
Update src/main/external-resources/renderers/Panasonic.conf

### DIFF
--- a/src/main/external-resources/renderers/Panasonic.conf
+++ b/src/main/external-resources/renderers/Panasonic.conf
@@ -4,18 +4,18 @@ UserAgentSearch=Panasonic MIL DLNA
 Video=true
 Audio=true
 Image=true
-SeekByTime=false
-DLNALocalizationRequired=true
+SeekByTime=exclusive
+DLNALocalizationRequired=false
 
 # CBRVideoBitrate is useful for renderers without SeekByTime support. It does time2byte conversion to support FF/RW.
 # Only possibility how to predict where we are when seeking is using CBR bitrate instead of VBR used by default
-# Making CBR stream by MEnocder is 3 times slower than using VBR so count with it if you have poor computer!
+# Making CBR stream by MEncoder is 3 times slower than using VBR so count with it if you have poor computer!
 # Speed can be hopefully optimized little bit in the future:
 # http://www.ps3mediaserver.org/forum/viewtopic.php?f=14&t=8883&p=53706&hilit=ditlew#p53700
 # http://www.ps3mediaserver.org/forum/viewtopic.php?f=11&t=11284&p=62765&hilit=1835#p62765
 # ByteToTimeseekRewindSeconds is used for finetuning so default is 0 
-CBRVideoBitrate=37000
-ByteToTimeseekRewindSeconds=0
+#CBRVideoBitrate=37000
+#ByteToTimeseekRewindSeconds=0
 
 TranscodeVideo=MPEGPSAC3
 TranscodeAudio=WAV
@@ -35,7 +35,7 @@ TranscodedVideoFileSize=0
 # If computer is low on resources it is better to avoid using bandwidth limit which is much CPU demanding
 # It is better to lower quality settings by defining "CustomMencoderQualitySettings".
 # By lowering quality also bitrate is decreased but it is not so CPU aggresive so it is preferred to use it this way
-MaxVideoBitrateMbps=90
+MaxVideoBitrateMbps=80
 CustomMencoderQualitySettings=keyint=5:vqscale=1:vqmin=3:vqmax=5
 CustomMencoderOptions=-vf softskip,expand=::::1:16\/9:4
 
@@ -72,11 +72,15 @@ StreamExtensions=
 MediaInfo=true
 
 Supported = f:mpegps|mpegts    v:mpeg1|mpeg2|mp4|h264    a:ac3|lpcm|aac|mpa	m:video/mpeg
-Supported = f:avi|divx    v:mp4|divx|mjpeg	a:mp3|lpcm|mpa|ac3	m:video/x-divx	qpel:yes	gmc:0
-Supported = f:mp4    v:mp4|h264	a:ac3|aac	m:video/mp4
+# Some TVs may have problems with mime type "x-msvideo" which is compatible with DivX and also MJPEG (digital camera) AVIs
+# Mime type "divx" is widely compatible with renderers but non-DivX AVI files doesn't have to be played at all
+# By default more widely supported "video/divx" is used but feel free to test "video/x-msvideo" which should be better choice
+#Supported = f:avi|divx    v:mp4|divx|mjpeg  a:mp3|lpcm|mpa|ac3	m:video/x-msvideo	qpel:yes|no	gmc:0
+Supported = f:avi|divx    v:mp4|divx|mjpeg	a:mp3|lpcm|mpa|ac3	m:video/divx	qpel:yes|no	gmc:0
+# MP4 is not supported natively (models 2010/2011?). If newer models have MP4 support, uncomment next line
+#Supported = f:mp4    v:mp4|h264	a:ac3|lpcm|aac	m:video/mp4
 Supported = f:wmv    v:wmv|vc1	a:wma	n:2	m:video/x-ms-wmv
 
-#Supported = f:lpcm  m:audio/L16
 Supported = f:wav	a:dts|lpcm	n:6	s:48000	m:audio/wav
 Supported = f:wav	n:2	s:48000	m:audio/wav
 Supported = f:mp3	n:2	m:audio/mpeg
@@ -110,17 +114,3 @@ Supported = f:tiff	m:image/tiff
 # Received on socket: User-Agent: Panasonic MIL DLNA CP UPnP/1.0
 # Received on socket: X-PANASONIC-DMP-Profile: MPEG_PS_PAL JPEG_SM PV_DIVX_DIV3 PV_DIVX_DIV4 PV_DIVX_DIVX PV_DIVX_DX50 PV_DRM_DIVX_DIV3 PV_DRM_DIVX_DIV4 PV_DRM_DIVX_DIVX PV_DRM_DIVX_DX50
 # Received on socket: X-PANASONIC-Registration: VklFUkEAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
-
-
-# I tested 4 combinations:
-# - SeekByTime = true
-# - SeekByTime = false
-# - TranscodedVideoFileSize=100000000000
-# - TranscodedVideoFileSize=0
-# Results (with version before 1.50, never tested it again with newer versions):
-# When SeekByTime=false and TranscodedVideoFileSize=0, transcoded file has no info about actual time(total time is visible) and seeking is somehow/sometimes possible.
-# When 99GB is set, I can see actual time but when seeking, time is visible but immediately freeze and TV will show corrupted data or movie starts from begining or from point where I started to seek.
-# When SeekByTime=true, PMS generates exceptions and movie starts from beginning always when I use seeking. It seems that TV maybe doesn't support seeking by time, but why PMS generates exceptions?  
-# When I tried TranscodedVideoFileSize=-1, seeking will start movie from beginning every time.
-# When TranscodedVideoFileSize is defined to something about 1GB, I can see actual time but seeking is working only for some minutes/seconds to forward. It means I can seek forward for few seconds but not more because it seems PMS will send end of file and streaming will freeze/file cannot be played.
-# When I set 10GB, behavior is same as for 99GB(mayble some TV limit about maximum size of file???)


### PR DESCRIPTION
Updated Panasonic conf which:
- supports FF/RW also for transcoded/remuxed video.
- slower CBR changed back to VBR (time2byte seek conversion not needed anymore)
- it also supports direct streaming of any XviD/DivX files with or without qpel option
- 2010/2011 models doesn't support MP4 natively so files are transcoded by default
