### PR TITLE
Updated POM to use the latest version of Thumbnailator.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@
 		<dependency>
 			<groupId>net.coobird</groupId>
 			<artifactId>thumbnailator</artifactId>
-			<version>0.4.2</version>
+			<version>0.4.4</version>
 		</dependency>
 
 		<!--


### PR DESCRIPTION
There were reports of OutOfMemoryErrors occuring when using Thumbnailator with the latest versions of Java 6 and 7. (Java 6 Update 45 and Java 7 Update 21)

Thumbnailator 0.4.4 addresses the OutOfMemoryError issue by fixing a bug that was preventing resources from being released after reading and writing images.

This should address the "OutOfMemoryError: Java heap space" problems encountered by some PS3 Media Server users. One such instance can be found in the following forum posting:
http://www.ps3mediaserver.org/forum/viewtopic.php?f=6&t=16692

For more information, please refer to the Issue Tracker of Thumbnailator:
http://code.google.com/p/thumbnailator/issues/detail?id=42
