### PR TITLE
Send thumbnails properly to Samsung 2012 ES and EH models

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,10 @@ Changelog:
         - allow the chapter folder prefix to be localized
         - hide chapter folders if the duration of the video is less than the chapter length
 
+    Misc:
+        - Send thumbnails properly to Samsung 2012 ES and EH models (thanks, dmitche3!)
+
+
 1.82.0 - 2013-06-03
 
     Engines:

--- a/src/main/external-resources/renderers/PS3.conf
+++ b/src/main/external-resources/renderers/PS3.conf
@@ -171,6 +171,13 @@ DLNALocalizationRequired = false
 # ByteToTimeseekRewindSeconds is used for fine tuning, so the default is 0
 # ByteToTimeseekRewindSeconds=0
 
+# ThumbnailAsResource: Set to true if the renderer requires the use of the
+# "res" element instead of the "albumArtURI" element for thumbnails in DLNA
+# reponses. E.g. Samsung 2012 models do not recognize the "albumArtURI"
+# element.
+# Default value is false, i.e. use "albumArtURI"
+# ThumbnailAsResource = 
+	 
 #-----------------------------------------------------------------------------
 # MEDIAINFO
 #

--- a/src/main/external-resources/renderers/SamsungAllShare.conf
+++ b/src/main/external-resources/renderers/SamsungAllShare.conf
@@ -32,6 +32,10 @@ Image=true
 SeekByTime=false
 TranscodeVideo=MPEGPSAC3
 TranscodeAudio=LPCM
+
+# Samsung 2012 models do not recognize the "albumArtURI" element, use "res" instead
+ThumbnailAsResource=true 
+
 DefaultVBVBufSize=true
 MuxH264ToMpegTS=true
 MuxDTSToMpeg=true

--- a/src/main/java/net/pms/configuration/RendererConfiguration.java
+++ b/src/main/java/net/pms/configuration/RendererConfiguration.java
@@ -90,6 +90,7 @@ public class RendererConfiguration {
 	private static final String STREAM_EXT = "StreamExtensions";
 	private static final String SUBTITLE_HTTP_HEADER = "SubtitleHttpHeader";
 	private static final String SUPPORTED = "Supported";
+	private static final String THUMBNAIL_AS_RESOURCE = "ThumbnailAsResource";
 	private static final String TRANSCODE_AUDIO_441KHZ = "TranscodeAudioTo441kHz";
 	private static final String TRANSCODE_AUDIO = "TranscodeAudio";
 	private static final String TRANSCODED_SIZE = "TranscodedVideoFileSize";
@@ -885,6 +886,17 @@ public class RendererConfiguration {
 
 	public boolean isDLNAOrgPNUsed() {
 		return getBoolean(DLNA_ORGPN_USE, true);
+	}
+
+	/**
+	 * Returns whether or not to use the "res" element instead of the "albumArtURI"
+	 * element for thumbnails in DLNA reponses. E.g. Samsung 2012 models do not
+	 * recognize the "albumArtURI" element. Default value is <code>false</code>.
+	 *
+	 * @return True if the "res" element should be used, false otherwise.
+	 */
+	public boolean getThumbNailAsResource() {
+		return getBoolean(THUMBNAIL_AS_RESOURCE, false);
 	}
 
 	/**

--- a/src/main/java/net/pms/dlna/DLNAResource.java
+++ b/src/main/java/net/pms/dlna/DLNAResource.java
@@ -1549,35 +1549,7 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 			}
 		}
 
-		String thumbURL = getThumbnailURL();
-		if (!isFolder() && (getFormat() == null || (getFormat() != null && thumbURL != null))) {
-			openTag(sb, "upnp:albumArtURI");
-			addAttribute(sb, "xmlns:dlna", "urn:schemas-dlna-org:metadata-1-0/");
-
-			if (getThumbnailContentType().equals(PNG_TYPEMIME) && !mediaRenderer.isForceJPGThumbnails()) {
-				addAttribute(sb, "dlna:profileID", "PNG_TN");
-			} else {
-				addAttribute(sb, "dlna:profileID", "JPEG_TN");
-			}
-
-			endTag(sb);
-			sb.append(thumbURL);
-			closeTag(sb, "upnp:albumArtURI");
-		}
-
-		if ((isFolder() || mediaRenderer.isForceJPGThumbnails()) && thumbURL != null) {
-			openTag(sb, "res");
-
-			if (getThumbnailContentType().equals(PNG_TYPEMIME) && !mediaRenderer.isForceJPGThumbnails()) {
-				addAttribute(sb, "protocolInfo", "http-get:*:image/png:DLNA.ORG_PN=PNG_TN");
-			} else {
-				addAttribute(sb, "protocolInfo", "http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_TN");
-			}
-
-			endTag(sb);
-			sb.append(thumbURL);
-			closeTag(sb, "res");
-		}
+		appendThumbnail(mediaRenderer, sb);
 
 		if (getLastModified() > 0) {
 			addXMLTagAndAttribute(sb, "dc:date", SDF_DATE.format(new Date(getLastModified())));
@@ -1621,6 +1593,64 @@ public abstract class DLNAResource extends HTTPResource implements Cloneable, Ru
 		}
 
 		return sb.toString();
+	}
+
+	/**
+	 * Generate and append the response for the thumbnail based on the
+	 * configuration of the renderer.
+	 *
+	 * @param mediaRenderer The renderer configuration.
+	 * @param sb The StringBuilder to append the response to.
+	 */
+	private void appendThumbnail(RendererConfiguration mediaRenderer, StringBuilder sb) {
+		String thumbURL = getThumbnailURL();
+	
+		if (!isFolder() && (getFormat() == null || (getFormat() != null && thumbURL != null))) {
+			if (mediaRenderer.getThumbNailAsResource()) {
+				// Samsung 2012 (ES and EH) models do not recognize the "albumArtURI" element.
+				// Instead, the "res" element should be used.
+				openTag(sb, "res");
+				addAttribute(sb, "resolution", getMedia().getResolution());
+
+				if (getThumbnailContentType().equals(PNG_TYPEMIME) && !mediaRenderer.isForceJPGThumbnails()) {
+					addAttribute(sb, "protocolInfo", "http-get:*:image/png:DLNA.ORG_PN=PNG_TN");
+				} else {
+					addAttribute(sb, "protocolInfo", "http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_TN");
+				}
+
+				endTag(sb);
+				sb.append(thumbURL);
+				closeTag(sb, "res");
+			} else {
+				// Renderers that can handle the "albumArtURI" element.
+				openTag(sb, "upnp:albumArtURI");
+				addAttribute(sb, "xmlns:dlna", "urn:schemas-dlna-org:metadata-1-0/");
+
+				if (getThumbnailContentType().equals(PNG_TYPEMIME) && !mediaRenderer.isForceJPGThumbnails()) {
+					addAttribute(sb, "dlna:profileID", "PNG_TN");
+				} else {
+					addAttribute(sb, "dlna:profileID", "JPEG_TN");
+				}
+
+				endTag(sb);
+				sb.append(thumbURL);
+				closeTag(sb, "upnp:albumArtURI");
+			}
+		}
+
+		if ((isFolder() || mediaRenderer.isForceJPGThumbnails()) && thumbURL != null) {
+			openTag(sb, "res");
+
+			if (getThumbnailContentType().equals(PNG_TYPEMIME) && !mediaRenderer.isForceJPGThumbnails()) {
+				addAttribute(sb, "protocolInfo", "http-get:*:image/png:DLNA.ORG_PN=PNG_TN");
+			} else {
+				addAttribute(sb, "protocolInfo", "http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_TN");
+			}
+
+			endTag(sb);
+			sb.append(thumbURL);
+			closeTag(sb, "res");
+		}
 	}
 
 	private String getRequestId(String rendererId) {


### PR DESCRIPTION
My revised implementation of the patches submitted by dmitche3 on the [forum](http://www.ps3mediaserver.org/forum/viewtopic.php?f=6&t=16209&p=79576#p77462).
