### PR TITLE
Prefer 'forced' subtitles

### DIFF
--- a/src/main/java/net/pms/encoders/Player.java
+++ b/src/main/java/net/pms/encoders/Player.java
@@ -272,8 +272,12 @@ public abstract class Player {
 						for (DLNAMediaSubtitle present_sub : media.getSubtitleTracksList()) {
 							if (present_sub.matchCode(sub) || sub.equals("*")) {
 								matchedSub = present_sub;
-								logger.trace("Found a match: " + matchedSub);
-								break;
+								if (present_sub.getFlavor() == null) {
+									logger.trace("Found a match: " + matchedSub);
+								} else {
+									logger.trace("Found a flavored match: " + matchedSub);
+									break;
+								}
 							}
 						}
 					}


### PR DESCRIPTION
Prefer -forced (i.e. flavored) subtitles above embedded subtitles.

I'm not sure what the intended meaning of flavors is, however, by merging this patch '-forced' subtitles take preference above embedded subtitles.
For me this seems to be the intended behavior, please verify.

Thanks
