### PR TITLE
Added suport for external subtitles to VLC Player and some improvements in audio track selection

### DIFF
--- a/src/main/java/net/pms/encoders/VLCVideo.java
+++ b/src/main/java/net/pms/encoders/VLCVideo.java
@@ -297,10 +297,10 @@ public class VLCVideo extends Player {
 
 		// Handle audio language
 		if (params.aid != null) { // User specified language at the client, acknowledge it
-			if (params.aid.getLang() == null || params.aid.getLang().equals("und")) { // VLC doesn't understand und, but does understand a non existant track
-				cmdList.add("--audio-" + disableSuffix);
-			} else { // Load by ID (better)
+			if (params.aid.getLang() == null || params.aid.getLang().equals("und")) { // VLC doesn't understand und, so try to get audio track by ID
 				cmdList.add("--audio-track=" + params.aid.getId());
+			} else {
+				cmdList.add("--audio-language=" + params.aid.getLang());
 			}
 		} else { // Not specified, use language from GUI
 			cmdList.add("--audio-language=" + configuration.getAudioLanguages());


### PR DESCRIPTION
Currently, external subtitles are not supported when using VLC Player. I made a little patch using a piece of code from FFmpegVideo.java. Hope it helps, because it helped me a lot.

Later, I discovered sometimes audio track is being skipped just because it's language is undetermined. So I made a new fix.
