### PR TITLE
pms/configuration/FormatConfiguration: Set match to true if extras are null

### DIFF
--- a/src/main/java/net/pms/configuration/FormatConfiguration.java
+++ b/src/main/java/net/pms/configuration/FormatConfiguration.java
@@ -246,6 +246,8 @@ public class FormatConfiguration {
 						matched = miExtras.get(MI_GMC).matcher(value).matches();
 					}
 				}
+			} else {
+				matched = true;
 			}
 
 			if (matched) {


### PR DESCRIPTION
Several media files are remuxed unnecessarily. When the extras are null, the current code defaults to remux. I believe this would be the better option. Is there any reason not to do it this way?
