### PR TITLE
Applying Patch for Issue 1317: support for Unicode (m3u8 Winamp)

### DIFF
--- a/src/main/java/net/pms/dlna/PlaylistFolder.java
+++ b/src/main/java/net/pms/dlna/PlaylistFolder.java
@@ -62,7 +62,17 @@ public class PlaylistFolder extends DLNAResource {
 			boolean pls = false;
 
 			try {
-				BufferedReader br = new BufferedReader(new FileReader(playlistfile));
+				BufferedReader br;
+				if ( playlistfile.getName().toLowerCase().endsWith(".m3u8") )
+				{
+					br = new BufferedReader(new InputStreamReader(new FileInputStream(playlistfile),"UTF-8"));
+					br.read(); // Skip byte order mark.
+				}
+				else
+				{
+					br = new BufferedReader(new FileReader(playlistfile));
+				}
+				
 				String line;
 
 				while (!m3u && !pls && (line = br.readLine()) != null) {


### PR DESCRIPTION
I have cleaned up the patch previously attached to URL posted below and attached one myself there:
https://code.google.com/p/ps3mediaserver/issues/detail?id=1317
- All the import statements (of the original attachment) are already present in the latest 1.90.2 snapshot as it is, so cleaned them up...
- The remainder of the patch is unchanged...
- I have compiled a repository here myself
- I tested it on a PS3 and it works fine now for the UTF-8 (unicode) m3u8 to be played with PMS

I have implemented this patch in a Fork of the PMS project...
This is my first tryout at GitHub to share something, so bare with me if I have done something wrong in the sharing process.
Hope you can now tick off Issue 1317 as fixed/implemented :+1: 
